### PR TITLE
fix: numpy binary incompatibility on Colab

### DIFF
--- a/day1/day1_data_engineering.ipynb
+++ b/day1/day1_data_engineering.ipynb
@@ -100,21 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "# ติดตั้ง libraries ทั้งหมด\n",
-    "!pip install -q google-genai \\\n",
-    "    docling \\\n",
-    "    'typer>=0.24.0' \\\n",
-    "    sentence-transformers \\\n",
-    "    qdrant-client \\\n",
-    "    langchain-text-splitters \\\n",
-    "    rank_bm25 \\\n",
-    "    pymupdf \\\n",
-    "    pythainlp \\\n",
-    "    scikit-learn \\\n",
-    "    rich\n",
-    "\n",
-    "print('✅ ติดตั้งเรียบร้อยแล้ว!')"
+    "%%time\n# ติดตั้ง libraries ทั้งหมด\n!pip install -q google-genai \\\n    docling \\\n    'typer>=0.24.0' \\\n    sentence-transformers \\\n    qdrant-client \\\n    langchain-text-splitters \\\n    rank_bm25 \\\n    pymupdf \\\n    pythainlp \\\n    scikit-learn \\\n    rich\n\nprint('✅ ติดตั้งเรียบร้อยแล้ว!')\nprint('⚠️ กรุณา Restart runtime: Runtime → Restart session → แล้ว Run ทุก cell ใหม่')"
    ]
   },
   {


### PR DESCRIPTION
## Summary

แก้ปัญหา `numpy.dtype size changed` error ที่เกิดบน Google Colab เมื่อ import `langchain_text_splitters`

## Changes

- ลบ `!pip install -q --upgrade numpy` ที่ทำให้ downgrade เป็น 1.26.4
- เพิ่มข้อความแจ้งเตือน `⚠️ กรุณา Restart runtime` หลังติดตั้ง

## Testing

1. เปิด notebook บน Colab
2. Run cell ติดตั้ง
3. Restart runtime
4. Run ทุก cell → ไม่มี numpy error

Fixes #1