### PR TITLE
fix: remove typer pin conflicting with docling

### DIFF
--- a/day1/day1_data_engineering.ipynb
+++ b/day1/day1_data_engineering.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n# ติดตั้ง libraries ทั้งหมด\n!pip install -q google-genai \\\n    'docling>=2.31' \\\n    'docling-ibm-models>=3.4' \\\n    'typer>=0.24.0' \\\n    sentence-transformers \\\n    qdrant-client \\\n    langchain-text-splitters \\\n    rank_bm25 \\\n    pymupdf \\\n    pythainlp \\\n    scikit-learn \\\n    rich\n\n# ล้าง cache ของ docling-models เพื่อป้องกัน ONNX file mismatch\nimport shutil, os\ncache_path = os.path.expanduser('~/.cache/huggingface/hub/models--ds4sd--docling-models')\nif os.path.exists(cache_path):\n    shutil.rmtree(cache_path)\n    print('🗑️ ล้าง docling-models cache แล้ว')\n\nprint('✅ ติดตั้งเรียบร้อยแล้ว!')\nprint('⚠️ กรุณา Restart runtime: Runtime → Restart session → แล้ว Run ทุก cell ใหม่')"
+    "%%time\n# ติดตั้ง libraries ทั้งหมด\n!pip install -q google-genai \\\n    docling \\\n    sentence-transformers \\\n    qdrant-client \\\n    langchain-text-splitters \\\n    rank_bm25 \\\n    pymupdf \\\n    pythainlp \\\n    scikit-learn \\\n    rich\n\n# ล้าง cache ของ docling-models เพื่อป้องกัน ONNX file mismatch\nimport shutil, os\ncache_path = os.path.expanduser('~/.cache/huggingface/hub/models--ds4sd--docling-models')\nif os.path.exists(cache_path):\n    shutil.rmtree(cache_path)\n    print('🗑️ ล้าง docling-models cache แล้ว')\n\nprint('✅ ติดตั้งเรียบร้อยแล้ว!')\nprint('⚠️ กรุณา Restart runtime: Runtime → Restart session → แล้ว Run ทุก cell ใหม่')"
    ]
   },
   {


### PR DESCRIPTION
## Summary

แก้ปัญหา `typer>=0.24.0` ที่ขัดกับ docling ทุก version ทำให้ pip install ล้มเหลว

## Changes

- ลบ `typer>=0.24.0` pin — ให้ docling install typer version ที่ compatible เอง
- ลบ `docling-ibm-models>=3.4` pin — ให้ docling จัดการ dependency เอง
- คงไว้: auto-clear docling cache + restart runtime warning

Fixes #3