### PR TITLE
feat: add 6 enhancements for international students learning Thai RAG

### DIFF
--- a/en/4hr/agentic_rag_4hr.ipynb
+++ b/en/4hr/agentic_rag_4hr.ipynb
@@ -54,6 +54,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### 📖 Thai Quick Reference\n\nCommon Thai words you'll see in the output and data:\n\n| Thai | Pronunciation | Meaning |\n|:-----|:-------------|:--------|\n| สวัสดี | sa-wat-dee | Hello |\n| ครับ / ค่ะ | krap / ka | Polite particle (male / female) |\n| คำถาม | kham-tham | Question |\n| คำตอบ | kham-tob | Answer |\n| ค้นหา | kon-ha | Search |\n| ข้อมูล | kor-moon | Data / Information |\n| ผลลัพธ์ | phon-lap | Result |\n| ตัวอย่าง | tua-yang | Example |\n| ปัญญาประดิษฐ์ | pan-ya pra-dit | Artificial Intelligence |\n| การเรียนรู้ | kan rian-roo | Learning |\n| เครื่อง | krueang | Machine |\n| แพทย์ | phaet | Doctor / Medical |\n| ธนาคาร | ta-na-kan | Bank |\n| การเกษตร | kan ka-set | Agriculture |\n| มหาวิทยาลัย | ma-ha wit-ta-ya-lai | University |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "---\n",
     "## 📢 Part 1: Data → VectorDB\n",
     "\n",

--- a/en/README.md
+++ b/en/README.md
@@ -18,6 +18,30 @@
 
 ---
 
+## 🌍 For International Students
+
+This workshop teaches how to build RAG systems for **Thai language data** using Google ADK & Gemini.
+
+**You don't need to read Thai!** Here's what to expect:
+- All **instructions, comments, and print messages** are in English
+- **Sample data** (documents, queries) is in Thai — this is the data your RAG pipeline processes
+- Every Thai string has an English translation as an inline comment: `# "translation"`
+- Case study data includes `# [EN]` block translations explaining the full context
+- Each notebook starts with a **Thai language explainer** describing key differences from English
+
+**Key things to know about Thai:**
+
+| Feature | English | Thai |
+|---------|---------|------|
+| Word separation | Spaces between words | No spaces — continuous script |
+| Tokenization | Split on spaces ✅ | Requires [PyThaiNLP](https://pythainlp.github.io/) |
+| Capitalization | Yes (A-Z, a-z) | No — single case only |
+| BM25 keyword search | Works out of the box | Needs special tokenizer |
+| Embedding model | English-only works | Must use multilingual (e.g., `multilingual-e5-large`) |
+
+
+---
+
 ## 🎯 Overview
 
 A 3-day workshop for undergraduate students on building **Retrieval-Augmented Generation (RAG)** and **AI Agents** end-to-end.

--- a/en/day1/day1_data_engineering.ipynb
+++ b/en/day1/day1_data_engineering.ipynb
@@ -398,6 +398,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 📖 Thai Quick Reference\n\nCommon Thai words you'll see in the output and data:\n\n| Thai | Pronunciation | Meaning |\n|:-----|:-------------|:--------|\n| สวัสดี | sa-wat-dee | Hello |\n| ครับ / ค่ะ | krap / ka | Polite particle (male / female) |\n| คำถาม | kham-tham | Question |\n| คำตอบ | kham-tob | Answer |\n| ค้นหา | kon-ha | Search |\n| ข้อมูล | kor-moon | Data / Information |\n| ผลลัพธ์ | phon-lap | Result |\n| ตัวอย่าง | tua-yang | Example |\n| ปัญญาประดิษฐ์ | pan-ya pra-dit | Artificial Intelligence |\n| การเรียนรู้ | kan rian-roo | Learning |\n| เครื่อง | krueang | Machine |\n| แพทย์ | phaet | Doctor / Medical |\n| ธนาคาร | ta-na-kan | Bank |\n| การเกษตร | kan ka-set | Agriculture |\n| มหาวิทยาลัย | ma-ha wit-ta-ya-lai | University |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "VB0q3P0hQfq7"
    },
@@ -417,6 +424,13 @@
     "| 🔎 | 1.9 Retrieval | Search for vectors similar to the query |\n",
     "\n",
     "> 💡 Today we will do **every step** from data preparation to retrieval — the full foundation of RAG!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 💡 Why does Thai benefit more from Dense search?\n\nWhen comparing alpha values, you'll notice **Thai performs better with higher alpha (more Dense)**:\n\n| Factor | English | Thai |\n|--------|---------|------|\n| BM25 quality | High — spaces provide clean tokens | Low — tokenization errors cause keyword misses |\n| Dense embedding quality | High | High (with multilingual model) |\n| Recommended alpha | `0.5` (balanced) | `0.7+` (favor Dense) |\n\n**Rule of thumb for Thai RAG:** Start with `alpha=0.7` (70% Dense, 30% Sparse) and tune from there.\nDense embeddings capture *semantic meaning* regardless of tokenization quality, making them more reliable for Thai text."
    ]
   },
   {

--- a/en/day2/day2_building_agents.ipynb
+++ b/en/day2/day2_building_agents.ipynb
@@ -823,6 +823,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 💡 Cross-Language Retrieval\n\nBecause we use a **multilingual embedding model** (`intfloat/multilingual-e5-large`), the RAG agent can actually answer queries in **any language** — even though the data is in Thai!\n\nTry asking the agent in English:\n```\n\"How does AI help Thai healthcare?\"\n```\nThe multilingual embeddings map both English and Thai into the same vector space, so an English query will still find relevant Thai documents. This is one of the most powerful features of multilingual RAG! 🌍"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/en/day3/day3_evaluation.ipynb
+++ b/en/day3/day3_evaluation.ipynb
@@ -216,6 +216,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 💡 Note: Thai RAGAS scores may differ from English\n\nWhen interpreting your RAGAS scores, keep in mind:\n\n| Metric | Thai vs English | Why |\n|--------|:---------------:|-----|\n| **Faithfulness** | Often lower | LLM judges sometimes struggle comparing Thai text spans |\n| **Answer Relevancy** | Similar | Multilingual embeddings handle Thai well |\n| **Context Precision** | Similar | Retrieval quality depends more on embedding model than language |\n| **Context Recall** | May be lower | Ground truth matching is harder for Thai due to paraphrasing |\n\n**Tips:**\n- Use **Gemini** as the judge LLM — it handles Thai significantly better than most alternatives\n- Don't compare Thai RAGAS scores directly with English benchmarks\n- Focus on **relative improvement** between experiments rather than absolute scores"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
## Enhancements for Foreign Learners

1. **README**: Added 'For International Students' section with Thai vs English comparison table
2. **Day 1**: Word boundary visual (already existed) + Hybrid Search note (why alpha=0.7+ for Thai)
3. **Day 2**: Cross-language retrieval note (EN query → TH data via multilingual embeddings)
4. **Day 3**: Thai RAGAS scoring note (why scores may differ from English benchmarks)
5. **Day 1 + 4hr**: Thai Quick Reference glossary (15 common words with pronunciation)

5 files changed, 59 insertions.