### PR TITLE
fix: suppress Docling OCR noise and HF_TOKEN warning (#58)

### DIFF
--- a/en/day1/day1_data_engineering.ipynb
+++ b/en/day1/day1_data_engineering.ipynb
@@ -1818,6 +1818,13 @@
    ],
    "source": [
     "%%time\n",
+    "# Suppress noisy warnings from Docling's OCR backend\n",
+    "import warnings\n",
+    "import logging\n",
+    "warnings.filterwarnings('ignore', category=UserWarning, module='huggingface_hub')\n",
+    "logging.getLogger('RapidOCR').setLevel(logging.WARNING)\n",
+    "logging.getLogger('docling').setLevel(logging.WARNING)\n",
+    "\n",
     "from docling.document_converter import DocumentConverter\n",
     "\n",
     "# Convert PDF with Docling\n",
@@ -1829,6 +1836,13 @@
     "print('📝 Markdown output from Docling:')\n",
     "print('=' * 60)\n",
     "display(Markdown(docling_markdown))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ⚠️ Note: Docling OCR and Thai text\n\nDocling uses **RapidOCR** as its default OCR engine, which downloads **Chinese PP-OCR models** (~40 MB).\nThese models are designed for Chinese characters and **may not accurately recognize Thai text** in scanned PDFs.\n\n**For this workshop**, our sample PDF is **text-based** (not scanned), so text extraction works fine without OCR.\nFor scanned Thai documents in production, consider:\n- Using `pytesseract` with the Thai language pack (`tha`)\n- Or using Google Cloud Vision API with Thai support"
    ]
   },
   {

--- a/th/day1/day1_data_engineering.ipynb
+++ b/th/day1/day1_data_engineering.ipynb
@@ -1606,6 +1606,13 @@
    ],
    "source": [
     "%%time\n",
+    "# ปิด warning ที่ไม่จำเป็นจาก OCR backend ของ Docling\n",
+    "import warnings\n",
+    "import logging\n",
+    "warnings.filterwarnings('ignore', category=UserWarning, module='huggingface_hub')\n",
+    "logging.getLogger('RapidOCR').setLevel(logging.WARNING)\n",
+    "logging.getLogger('docling').setLevel(logging.WARNING)\n",
+    "\n",
     "from docling.document_converter import DocumentConverter\n",
     "\n",
     "# แปลง PDF ด้วย Docling\n",
@@ -1617,6 +1624,13 @@
     "print('📝 ผลลัพธ์ Markdown จาก Docling:')\n",
     "print('=' * 60)\n",
     "display(Markdown(docling_markdown))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ⚠️ หมายเหตุ: Docling OCR กับข้อความภาษาไทย\n\nDocling ใช้ **RapidOCR** เป็น OCR engine เริ่มต้น ซึ่งจะดาวน์โหลด **โมเดล PP-OCR ภาษาจีน** (~40 MB)\nโมเดลเหล่านี้ออกแบบมาสำหรับตัวอักษรจีน และ**อาจอ่านภาษาไทยไม่ถูกต้อง**ในกรณี PDF ที่เป็นภาพสแกน\n\n**สำหรับ workshop นี้** PDF ตัวอย่างเป็น **text-based** (ไม่ใช่ภาพสแกน) จึงดึงข้อความได้ปกติโดยไม่ต้องพึ่ง OCR\nสำหรับเอกสารสแกนภาษาไทยในงานจริง ควรพิจารณา:\n- ใช้ `pytesseract` พร้อม Thai language pack (`tha`)\n- หรือใช้ Google Cloud Vision API ที่รองรับภาษาไทย"
    ]
   },
   {


### PR DESCRIPTION
Fixes #58

- Suppress RapidOCR verbose `[INFO]` logs (~40 MB Chinese model download messages)
- Suppress `HF_TOKEN` UserWarning from huggingface_hub
- Add markdown cell explaining PP-OCR Chinese model limitation for Thai text
- Suggest alternatives for scanned Thai PDFs

Applied to both `th/` and `en/` `day1_data_engineering.ipynb`